### PR TITLE
Represent Font as Void* instead of empty struct 

### DIFF
--- a/src/lib_sdl2_ttf.cr
+++ b/src/lib_sdl2_ttf.cr
@@ -1,7 +1,6 @@
 @[Link("SDL2_ttf")]
 lib LibSDL2_TTF
-  struct Font
-  end
+  alias Font = Void*
 
   fun init = TTF_Init() : Int32
   fun quit = TTF_Quit() : Void


### PR DESCRIPTION
(empty structs are not allowed in Crystal 0.7.4).
